### PR TITLE
Analytics Commands & Premium Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ To get the bot running, you must configure a number of things.
 BOT_TOKEN: str = # the discord bot token
 ENVIRONMENT: Literal["DEV", "PROD"] = # how to run the bot (such as whether to use topgg integration)
 WEBSERVER_PORT: int = # the port to listen for offline status requests
+GUMROAD_PRODUCT_ID: str = # the gumroad product id
 
 class REDIS:
     HOST: str = # the redis host

--- a/cogs/all-link.py
+++ b/cogs/all-link.py
@@ -86,8 +86,6 @@ class AllLink(commands.Cog):
             LogLevel.DEBUG, f"All link g/{interaction.guild.id} r/{role.id}"
         )
 
-        return self.client.incr_counter("all_link")
-
     @all_commands.command()
     @app_commands.describe(role="Select a role to unlink")
     @check_any(command_available, is_owner)
@@ -129,8 +127,6 @@ class AllLink(commands.Cog):
         self.client.log(
             LogLevel.DEBUG, f"All link g/{interaction.guild.id} r/{role.id}"
         )
-
-        return self.client.incr_counter("all_unlink")
 
     @exclude_commands.command(name="add")
     @app_commands.describe(channel="Select a channel to exclude")
@@ -183,8 +179,6 @@ class AllLink(commands.Cog):
             LogLevel.DEBUG, f"All add exception g/{interaction.guild.id} c/{channel.id}"
         )
 
-        return self.client.incr_counter("all_add_exception")
-
     @exclude_commands.command(name="remove")
     @app_commands.describe(channel="Select a channel to un-exclude")
     @check_any(command_available, is_owner)
@@ -228,8 +222,6 @@ class AllLink(commands.Cog):
             f"All remove exception g/{interaction.guild.id} c/{channel.id}",
         )
 
-        return self.client.incr_counter("all_remove_exception")
-
     @suffix_commands.command(name="add")
     @app_commands.describe(
         suffix="The suffix to add to your username when joining any channel"
@@ -260,8 +252,6 @@ class AllLink(commands.Cog):
             LogLevel.DEBUG, f"All add suffix g/{interaction.guild.id} s/{suffix}"
         )
 
-        return self.client.incr_counter("all_add_suffix")
-
     @suffix_commands.command(name="remove")
     @check_any(command_available, is_owner)
     @app_commands.checks.has_permissions(administrator=True)
@@ -280,8 +270,6 @@ class AllLink(commands.Cog):
         await interaction.response.send_message("Removed the username suffix rule")
 
         self.client.log(LogLevel.DEBUG, f"All remove suffix g/{interaction.guild.id}")
-
-        return self.client.incr_counter("all_remove_suffix")
 
     @reverse_commands.command(name="link")
     @app_commands.describe(role="Select a role to reverse link")
@@ -325,8 +313,6 @@ class AllLink(commands.Cog):
             LogLevel.DEBUG, f"All reverse link g/{interaction.guild.id} r/{role.id}"
         )
 
-        return self.client.incr_counter("all_reverse_link")
-
     @reverse_commands.command(name="unlink")
     @app_commands.describe(role="Select a role to un-reverse link")
     @check_any(command_available, is_owner)
@@ -366,8 +352,6 @@ class AllLink(commands.Cog):
         self.client.log(
             LogLevel.DEBUG, f"All reverse unlink g/{interaction.guild.id} r/{role.id}"
         )
-
-        return self.client.incr_counter("all_reverse_unlink")
 
 
 async def setup(client: VCRolesClient):

--- a/cogs/analytics.py
+++ b/cogs/analytics.py
@@ -1,0 +1,246 @@
+import datetime as dt
+import io
+import json
+
+import discord
+from discord import Interaction, app_commands
+from discord.ext import commands, tasks
+
+from utils.client import VCRolesClient
+
+
+class Analytics(commands.Cog):
+    def __init__(self, client: VCRolesClient):
+        self.client = client
+        self.time_spent_loop.start()
+
+    async def cog_unload(self):
+        self.time_spent_loop.cancel()
+
+        return await super().cog_unload()
+
+    analytic_commands = app_commands.Group(
+        name="analytics", description="Use to enable or disable analytics"
+    )
+
+    @analytic_commands.command(name="toggle")
+    @app_commands.describe(
+        channel="Channel to send analytics to:",
+        enable="Enable analytics:",
+    )
+    async def toggle_analytics(
+        self, interaction: Interaction, enable: bool, channel: discord.TextChannel
+    ):
+        """PREMIUM - Use to toggle analytics"""
+        if not interaction.guild:
+            return await interaction.response.send_message(
+                "This command can only be used in a server"
+            )
+
+        guild = await self.client.db.get_guild_data(interaction.guild.id)
+
+        if not guild.premium:
+            embed = discord.Embed(
+                title="Premium Required",
+                description="Sorry, you cannot enable analytics in this server - consider upgrading to premium to unlock this. https://cde90.gumroad.com/l/vcroles",
+                colour=discord.Colour.red(),
+            )
+            return await interaction.response.send_message(embed=embed)
+
+        if enable:
+            await self.client.db.update_guild_data(
+                interaction.guild.id, analytics=str(channel.id)
+            )
+            embed = discord.Embed(
+                title="Analytics Enabled",
+                description=f"Analytics have been enabled in {channel.mention}",
+                colour=discord.Colour.green(),
+            )
+            return await interaction.response.send_message(embed=embed)
+
+        await self.client.db.update_guild_data(interaction.guild.id, analytics=None)
+        embed = discord.Embed(
+            title="Analytics Disabled",
+            description="Analytics have been disabled",
+            colour=discord.Colour.green(),
+        )
+        return await interaction.response.send_message(embed=embed)
+
+    @tasks.loop(minutes=1)
+    async def time_spent_loop(self):
+        guilds = await self.client.db.get_analytic_guilds()
+
+        for guild in guilds:
+            if not guild.analytics:
+                continue
+
+            # loop through every voice channel in the guild
+            # for each channel, get the number of members in it
+            # add the total number of members in voice channels
+            # to the redis database for hash guild:id:analytics -> voice_minutes
+            g = self.client.get_guild(int(guild.id))
+            if not g:
+                continue
+            total = 0
+            for channel in g.voice_channels:
+                total += len(channel.members)
+
+            await self.client.ar.hincrby(
+                f"guild:{guild.id}:analytics", "voice_minutes", total
+            )
+
+    @time_spent_loop.before_loop
+    async def before_time_spent_loop(self):
+        await self.client.wait_until_ready()
+
+    async def get_analytic_embed(self, guild: str) -> discord.Embed:
+        analytics = await self.client.ar.hgetall(f"guild:{guild}:analytics")
+
+        embed = discord.Embed(
+            title="VC Roles Analytics",
+            description="Here are your analytics for the last 24 hours",
+            colour=discord.Colour.green(),
+        )
+
+        embed.add_field(
+            name="Voice Minutes",
+            value=analytics.get("voice_minutes", 0),
+            inline=False,
+        )
+
+        embed.add_field(
+            name="Voice Channels Joined / Left / Changed",
+            value=f"{analytics.get('voice_channel_joins', 0)} / {analytics.get('voice_channel_leaves', 0)} / {analytics.get('voice_channel_changes', 0)}",
+            inline=False,
+        )
+
+        embed.add_field(
+            name="Roles Added / Removed",
+            value=f"{analytics.get('roles_added', 0)} / {analytics.get('roles_removed', 0)}",
+            inline=False,
+        )
+
+        embed.add_field(
+            name="Commands Used",
+            value=analytics.get("commands_used", 0),
+            inline=False,
+        )
+
+        embed.add_field(
+            name="Generated Voice Channels",
+            value=analytics.get("generated_voice_channels", 0),
+            inline=False,
+        )
+
+        embed.add_field(
+            name="TTS Messages Sent",
+            value=analytics.get("tts_messages_sent", 0),
+            inline=False,
+        )
+
+        return embed
+
+    @tasks.loop(time=dt.time(hour=0, minute=0))
+    async def analytics_loop(self):
+        guilds = await self.client.db.get_analytic_guilds()
+
+        for guild in guilds:
+            if not guild.analytics:
+                continue
+
+            g = self.client.get_guild(int(guild.id))
+            if not g:
+                continue
+
+            channel = g.get_channel(int(guild.analytics))
+            if not channel or not isinstance(channel, discord.TextChannel):
+                continue
+
+            embed = await self.get_analytic_embed(guild.id)
+
+            await channel.send(embed=embed)
+
+            await self.client.ar.rename(  # type: ignore
+                f"guild:{guild.id}:analytics",
+                f"guild:{guild.id}:analytics:{dt.datetime.utcnow().strftime('%Y-%m-%d')}",
+            )
+            # set the new hash to expire in 30 days
+            await self.client.ar.expire(
+                f"guild:{guild.id}:analytics:{dt.datetime.utcnow().strftime('%Y-%m-%d')}",
+                30 * 24 * 60 * 60,
+            )
+
+    @analytics_loop.before_loop
+    async def before_analytics_loop(self):
+        await self.client.wait_until_ready()
+
+    @analytic_commands.command(name="view")
+    async def view_analytics(self, interaction: Interaction):
+        """PREMIUM - Use to view analytics"""
+        if not interaction.guild:
+            return await interaction.response.send_message(
+                "This command can only be used in a server"
+            )
+
+        guild = await self.client.db.get_guild_data(interaction.guild.id)
+
+        if not guild.premium:
+            embed = discord.Embed(
+                title="Premium Required",
+                description="Sorry, you cannot view analytics in this server - consider upgrading to premium to unlock this. https://cde90.gumroad.com/l/vcroles",
+                colour=discord.Colour.red(),
+            )
+            return await interaction.response.send_message(embed=embed)
+
+        embed = await self.get_analytic_embed(guild.id)
+
+        return await interaction.response.send_message(embed=embed)
+
+    @analytic_commands.command(name="export")
+    async def export_analytics(self, interaction: Interaction):
+        """PREMIUM - Export past 30 days of analytics"""
+        if not interaction.guild:
+            return await interaction.response.send_message(
+                "This command can only be used in a server"
+            )
+
+        guild = await self.client.db.get_guild_data(interaction.guild.id)
+
+        if not guild.premium:
+            embed = discord.Embed(
+                title="Premium Required",
+                description="Sorry, you cannot export analytics in this server - consider upgrading to premium to unlock this. https://cde90.gumroad.com/l/vcroles",
+                colour=discord.Colour.red(),
+            )
+            return await interaction.response.send_message(embed=embed)
+
+        analytics = await self.client.ar.keys(f"guild:{guild.id}:analytics:*")
+
+        if not analytics:
+            embed = discord.Embed(
+                title="No Analytics Found",
+                description="Sorry, there are no analytics to export",
+                colour=discord.Colour.red(),
+            )
+            return await interaction.response.send_message(embed=embed)
+
+        analytics = await self.client.ar.mget(*analytics)
+
+        analytics = [json.loads(a) for a in analytics]
+
+        analytics = {k: sum(d[k] for d in analytics) for k in analytics[0]}
+
+        analytics = json.dumps(analytics)
+
+        analytics = io.BytesIO(analytics.encode("utf-8"))
+
+        analytics.seek(0)
+
+        return await interaction.response.send_message(
+            "Here is your analytics export",
+            file=discord.File(analytics, filename="analytics.json"),
+        )
+
+
+async def setup(client: VCRolesClient):
+    await client.add_cog(Analytics(client))

--- a/cogs/analytics.py
+++ b/cogs/analytics.py
@@ -35,6 +35,7 @@ class Analytics(commands.Cog):
     @app_commands.describe(
         enable="Enable analytics:",
     )
+    @app_commands.checks.has_permissions(administrator=True)
     async def toggle_analytics(self, interaction: Interaction, enable: bool):
         """PREMIUM - Use to toggle analytics"""
         if not interaction.guild:
@@ -168,6 +169,7 @@ class Analytics(commands.Cog):
         await self.client.wait_until_ready()
 
     @analytic_commands.command(name="view")
+    @app_commands.checks.has_permissions(administrator=True)
     async def view_analytics(self, interaction: Interaction):
         """PREMIUM - Use to view analytics"""
         if not interaction.guild:
@@ -198,6 +200,7 @@ class Analytics(commands.Cog):
         return await interaction.response.send_message(embed=embed)
 
     @analytic_commands.command(name="export")
+    @app_commands.checks.has_permissions(administrator=True)
     async def export_analytics(self, interaction: Interaction):
         """PREMIUM - Export past 30 days of analytics"""
         if not interaction.guild:
@@ -270,6 +273,7 @@ class Analytics(commands.Cog):
         )
 
     @analytic_commands.command(name="graph")
+    @app_commands.checks.has_permissions(administrator=True)
     async def graph_analytics(
         self, interaction: Interaction, timeframe: Literal["hour", "day"] = "hour"
     ):

--- a/cogs/analytics.py
+++ b/cogs/analytics.py
@@ -57,7 +57,7 @@ class Analytics(commands.Cog):
         if enable:
             embed = discord.Embed(
                 title="Analytics Enabled",
-                description=f"Analytics have been enabled. To view your analytics, use `/analytics graph`, `/analytics view` or `/analytics export`.\nTo disable analytics, use `/analytics toggle false`",
+                description="Analytics have been enabled. To view your analytics, use `/analytics graph`, `/analytics view` or `/analytics export`.\nTo disable analytics, use `/analytics toggle false`",
                 colour=discord.Colour.green(),
             )
             return await interaction.response.send_message(embed=embed)

--- a/cogs/analytics.py
+++ b/cogs/analytics.py
@@ -33,12 +33,9 @@ class Analytics(commands.Cog):
 
     @analytic_commands.command(name="toggle")
     @app_commands.describe(
-        channel="Channel to send analytics to:",
         enable="Enable analytics:",
     )
-    async def toggle_analytics(
-        self, interaction: Interaction, enable: bool, channel: discord.TextChannel
-    ):
+    async def toggle_analytics(self, interaction: Interaction, enable: bool):
         """PREMIUM - Use to toggle analytics"""
         if not interaction.guild:
             return await interaction.response.send_message(
@@ -56,17 +53,14 @@ class Analytics(commands.Cog):
             return await interaction.response.send_message(embed=embed)
 
         if enable:
-            await self.client.db.update_guild_data(
-                interaction.guild.id, analytics=str(channel.id)
-            )
             embed = discord.Embed(
                 title="Analytics Enabled",
-                description=f"Analytics have been enabled in {channel.mention}",
+                description=f"Analytics have been enabled. To view your analytics, use `/analytics graph`, `/analytics view` or `/analytics export`.\nTo disable analytics, use `/analytics toggle false`",
                 colour=discord.Colour.green(),
             )
             return await interaction.response.send_message(embed=embed)
 
-        await self.client.db.update_guild_data(interaction.guild.id, analytics="None")
+        await self.client.db.update_guild_data(interaction.guild.id, analytics=False)
         embed = discord.Embed(
             title="Analytics Disabled",
             description="Analytics have been disabled",
@@ -158,18 +152,6 @@ class Analytics(commands.Cog):
         for guild in guilds:
             if not guild.analytics:
                 continue
-
-            g = self.client.get_guild(int(guild.id))
-            if not g:
-                continue
-
-            channel = g.get_channel(int(guild.analytics))
-            if not channel or not isinstance(channel, discord.TextChannel):
-                continue
-
-            embed = await self.get_analytic_embed(guild.id)
-
-            await channel.send(embed=embed)
 
             await self.client.ar.rename(  # type: ignore
                 f"guild:{guild.id}:analytics",

--- a/cogs/analytics.py
+++ b/cogs/analytics.py
@@ -1,18 +1,17 @@
-import datetime as dt
-from typing import Literal
-import io
 import csv
+import datetime as dt
+import io
+from typing import Literal
 
 import matplotlib
 
 matplotlib.use("Agg")
 
-from matplotlib.figure import Figure
-import matplotlib.dates as mdates
-
 import discord
+import matplotlib.dates as mdates
 from discord import Interaction, app_commands
 from discord.ext import commands, tasks
+from matplotlib.figure import Figure
 
 from utils.client import VCRolesClient
 

--- a/cogs/analytics.py
+++ b/cogs/analytics.py
@@ -21,9 +21,11 @@ class Analytics(commands.Cog):
     def __init__(self, client: VCRolesClient):
         self.client = client
         self.time_spent_loop.start()
+        self.analytics_loop.start()
 
     async def cog_unload(self):
         self.time_spent_loop.cancel()
+        self.analytics_loop.cancel()
 
         return await super().cog_unload()
 
@@ -278,9 +280,10 @@ class Analytics(commands.Cog):
         self, interaction: Interaction, timeframe: Literal["hour", "day"] = "hour"
     ):
         """PREMIUM - Create a graph of hourly/daily analytics"""
+        await interaction.response.defer()
 
         if not interaction.guild:
-            return await interaction.response.send_message(
+            return await interaction.followup.send(
                 "This command can only be used in a server"
             )
 
@@ -292,7 +295,7 @@ class Analytics(commands.Cog):
                 description="Sorry, you cannot view analytics in this server - consider upgrading to premium to unlock this. https://cde90.gumroad.com/l/vcroles",
                 colour=discord.Colour.red(),
             )
-            return await interaction.response.send_message(embed=embed)
+            return await interaction.followup.send(embed=embed)
 
         if not guild.analytics:
             embed = discord.Embed(
@@ -300,7 +303,7 @@ class Analytics(commands.Cog):
                 description="Analytics have been disabled. Use `/analytics toggle` to enable them",
                 colour=discord.Colour.green(),
             )
-            return await interaction.response.send_message(embed=embed)
+            return await interaction.followup.send(embed=embed)
 
         if timeframe == "hour":
             analytics = await self.client.ar.hgetall(f"guild:{guild.id}:analytics")
@@ -310,7 +313,7 @@ class Analytics(commands.Cog):
                     description="Sorry, there are no analytics to graph",
                     colour=discord.Colour.red(),
                 )
-                return await interaction.response.send_message(embed=embed)
+                return await interaction.followup.send(embed=embed)
 
             hourly_voice_minutes: list[int] = []
             hourly_voice_channel_joins: list[int] = []
@@ -375,7 +378,7 @@ class Analytics(commands.Cog):
 
             buffer.seek(0)
 
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 "Here is your analytics graph",
                 file=discord.File(buffer, "analytics.png"),
             )
@@ -389,7 +392,7 @@ class Analytics(commands.Cog):
                     description="Sorry, there are not enough analytics to graph",
                     colour=discord.Colour.red(),
                 )
-                return await interaction.response.send_message(embed=embed)
+                return await interaction.followup.send(embed=embed)
 
             analytic_days.sort()
             analytic_days.append(f"guild:{guild.id}:analytics")
@@ -470,7 +473,7 @@ class Analytics(commands.Cog):
 
             buffer.seek(0)
 
-            await interaction.response.send_message(
+            await interaction.followup.send(
                 "Here is your analytics graph",
                 file=discord.File(buffer, "analytics.png"),
             )

--- a/cogs/analytics.py
+++ b/cogs/analytics.py
@@ -292,10 +292,7 @@ class Analytics(commands.Cog):
         self, interaction: Interaction, timeframe: Literal["hour", "day"] = "hour"
     ):
         """PREMIUM - Create a graph of hourly/daily analytics"""
-        # we want to create a graph of the last 30 days of analytics if day is selected
-        # or the last 24 hours if hour is selected
-        # we want to create separate graphs for each of the following:
-        # voice minutes, voice channel joins, voice channel leaves, voice channel changes, roles added, roles removed, commands used, generated voice channels, tts messages sent
+
         if not interaction.guild:
             return await interaction.response.send_message(
                 "This command can only be used in a server"
@@ -328,10 +325,6 @@ class Analytics(commands.Cog):
                     colour=discord.Colour.red(),
                 )
                 return await interaction.response.send_message(embed=embed)
-
-            # create a graph of the last 24 hours of analytics
-            # the keys we want look like this:
-            # f"{item}-{datetime.datetime.utcnow().strftime('%H')}"
 
             hourly_voice_minutes: list[int] = []
             hourly_voice_channel_joins: list[int] = []
@@ -366,33 +359,33 @@ class Analytics(commands.Cog):
 
             def get_figure_hourly() -> Figure:
                 fig = Figure()
-                ax = fig.subplots()
+                ax = fig.subplots()  # type: ignore
 
-                ax.plot(hourly_voice_minutes, label="Voice Minutes")
-                ax.plot(hourly_voice_channel_joins, label="Voice Channel Joins")
-                ax.plot(hourly_voice_channel_leaves, label="Voice Channel Leaves")
-                ax.plot(hourly_voice_channel_changes, label="Voice Channel Changes")
-                ax.plot(hourly_roles_added, label="Roles Added")
-                ax.plot(hourly_roles_removed, label="Roles Removed")
-                ax.plot(hourly_commands_used, label="Commands Used")
-                ax.plot(
+                ax.plot(hourly_voice_minutes, label="Voice Minutes")  # type: ignore
+                ax.plot(hourly_voice_channel_joins, label="Voice Channel Joins")  # type: ignore
+                ax.plot(hourly_voice_channel_leaves, label="Voice Channel Leaves")  # type: ignore
+                ax.plot(hourly_voice_channel_changes, label="Voice Channel Changes")  # type: ignore
+                ax.plot(hourly_roles_added, label="Roles Added")  # type: ignore
+                ax.plot(hourly_roles_removed, label="Roles Removed")  # type: ignore
+                ax.plot(hourly_commands_used, label="Commands Used")  # type: ignore
+                ax.plot(  # type: ignore
                     hourly_generated_voice_channels, label="Generated Voice Channels"
                 )
-                ax.plot(hourly_tts_messages_sent, label="TTS Messages Sent")
+                ax.plot(hourly_tts_messages_sent, label="TTS Messages Sent")  # type: ignore
 
-                ax.set_xlabel("Hour")
-                ax.set_xticks(range(0, 24, 3))
-                ax.set_ylabel("Count")
-                ax.set_title("Hourly Analytics")
+                ax.set_xlabel("Hour")  # type: ignore
+                ax.set_xticks(range(0, 24, 3))  # type: ignore
+                ax.set_ylabel("Count")  # type: ignore
+                ax.set_title("Hourly Analytics")  # type: ignore
 
-                ax.legend()
+                ax.legend()  # type: ignore
 
                 return fig
 
             fig = await self.client.loop.run_in_executor(None, get_figure_hourly)
 
             buffer = io.BytesIO()
-            fig.savefig(buffer, format="png")
+            fig.savefig(buffer, format="png")  # type: ignore
 
             buffer.seek(0)
 
@@ -412,16 +405,8 @@ class Analytics(commands.Cog):
                 )
                 return await interaction.response.send_message(embed=embed)
 
-            # sort analytics by date
-            # the keys look like this:
-            # f"guild:{guild.id}:analytics:{dt.datetime.utcnow().strftime('%Y-%m-%d')}"
             analytic_days.sort()
-            # add the current day to the end of the list
             analytic_days.append(f"guild:{guild.id}:analytics")
-
-            # create a graph of the last 30 days of analytics
-            # the keys we want look like this:
-            # f"{item}"
 
             daily_voice_minutes: list[int] = []
             daily_voice_channel_joins: list[int] = []
@@ -463,39 +448,39 @@ class Analytics(commands.Cog):
 
             def get_figure_daily() -> Figure:
                 fig = Figure()
-                ax = fig.subplots()
+                ax = fig.subplots()  # type: ignore
 
-                ax.plot(dates, daily_voice_minutes, label="Voice Minutes")
-                ax.plot(dates, daily_voice_channel_joins, label="Voice Channel Joins")
-                ax.plot(dates, daily_voice_channel_leaves, label="Voice Channel Leaves")
-                ax.plot(
+                ax.plot(dates, daily_voice_minutes, label="Voice Minutes")  # type: ignore
+                ax.plot(dates, daily_voice_channel_joins, label="Voice Channel Joins")  # type: ignore
+                ax.plot(dates, daily_voice_channel_leaves, label="Voice Channel Leaves")  # type: ignore
+                ax.plot(  # type: ignore
                     dates, daily_voice_channel_changes, label="Voice Channel Changes"
                 )
-                ax.plot(dates, daily_roles_added, label="Roles Added")
-                ax.plot(dates, daily_roles_removed, label="Roles Removed")
-                ax.plot(dates, daily_commands_used, label="Commands Used")
-                ax.plot(
+                ax.plot(dates, daily_roles_added, label="Roles Added")  # type: ignore
+                ax.plot(dates, daily_roles_removed, label="Roles Removed")  # type: ignore
+                ax.plot(dates, daily_commands_used, label="Commands Used")  # type: ignore
+                ax.plot(  # type: ignore
                     dates,
                     daily_generated_voice_channels,
                     label="Generated Voice Channels",
                 )
-                ax.plot(dates, daily_tts_messages_sent, label="TTS Messages Sent")
+                ax.plot(dates, daily_tts_messages_sent, label="TTS Messages Sent")  # type: ignore
 
-                ax.xaxis.set_major_formatter(mdates.DateFormatter("%d/%m/%y"))
+                ax.xaxis.set_major_formatter(mdates.DateFormatter("%d/%m/%y"))  # type: ignore
                 interval = len(dates) // 5
-                ax.xaxis.set_major_locator(mdates.DayLocator(interval=interval))
-                ax.set_xlabel("Day")
-                ax.set_ylabel("Count")
-                ax.set_title("Daily Analytics")
+                ax.xaxis.set_major_locator(mdates.DayLocator(interval=interval))  # type: ignore
+                ax.set_xlabel("Day")  # type: ignore
+                ax.set_ylabel("Count")  # type: ignore
+                ax.set_title("Daily Analytics")  # type: ignore
 
-                ax.legend()
+                ax.legend()  # type: ignore
 
                 return fig
 
             fig = await self.client.loop.run_in_executor(None, get_figure_daily)
 
             buffer = io.BytesIO()
-            fig.savefig(buffer, format="png")
+            fig.savefig(buffer, format="png")  # type: ignore
 
             buffer.seek(0)
 

--- a/cogs/force-unlink.py
+++ b/cogs/force-unlink.py
@@ -55,8 +55,6 @@ class UnLink(commands.Cog):
             f"Force Unlinked c/{channel_id} g/{interaction.guild.id}",
         )
 
-        return self.client.incr_counter("forceunlink")
-
 
 async def setup(client: VCRolesClient):
     await client.add_cog(UnLink(client))

--- a/cogs/generator-admin.py
+++ b/cogs/generator-admin.py
@@ -259,8 +259,6 @@ class VoiceGen(commands.Cog):
             f"Created default generator g/{interaction.guild.id}",
         )
 
-        return self.client.incr_counter("voice_generator_create")
-
     @create_commands.command()
     @app_commands.describe(
         category_name="Name of generator category",
@@ -344,8 +342,6 @@ class VoiceGen(commands.Cog):
             f"Created numbered generator g/{interaction.guild.id}",
         )
 
-        return self.client.incr_counter("voice_generator_create")
-
     @create_commands.command()
     @app_commands.describe(
         category_name="Name of generator category",
@@ -422,8 +418,6 @@ class VoiceGen(commands.Cog):
             LogLevel.DEBUG,
             f"Created cloned generator g/{interaction.guild.id}",
         )
-
-        return self.client.incr_counter("voice_generator_create")
 
     @create_commands.command()
     @app_commands.describe(
@@ -508,8 +502,6 @@ class VoiceGen(commands.Cog):
             f"Created custom name generator g/{interaction.guild.id}",
         )
 
-        return self.client.incr_counter("voice_generator_create")
-
     @generator_commands.command()
     @app_commands.describe(generator="The generator channel to edit.")
     @commands.bot_has_permissions(manage_channels=True)
@@ -551,8 +543,6 @@ class VoiceGen(commands.Cog):
             LogLevel.DEBUG,
             f"Removed generator g/{interaction.guild.id} c/{generator.id}",
         )
-
-        return self.client.incr_counter("voice_generator_remove")
 
     @generator_commands.command()
     @app_commands.describe(
@@ -619,8 +609,6 @@ class VoiceGen(commands.Cog):
             f"Set {option} to {state} in g/{interaction.guild.id} c/{generator.id}",
         )
 
-        return self.client.incr_counter("voice_generator_toggle")
-
     @generator_commands.command()
     @app_commands.describe(
         generator="The generator channel to edit.",
@@ -661,8 +649,6 @@ class VoiceGen(commands.Cog):
             LogLevel.DEBUG,
             f"Listed options for g/{interaction.guild.id} c/{generator.id}",
         )
-
-        return self.client.incr_counter("voice_generator_options")
 
     @generator_commands.command(name="role")
     @app_commands.describe(
@@ -709,8 +695,6 @@ class VoiceGen(commands.Cog):
             f"Set default role for g/{interaction.guild.id} c/{generator.id} to {default_role.id}",
         )
 
-        return self.client.incr_counter("voice_generator_role")
-
     @generator_commands.command(name="restrict_role")
     @app_commands.describe(
         role="The role to restrict generators for (to remove select @everyone)",
@@ -756,8 +740,6 @@ class VoiceGen(commands.Cog):
             f"Set restricted role for g/{interaction.guild.id} c/{generator.id} to {role.id}",
         )
 
-        return self.client.incr_counter("voice_generator_restrict_role")
-
     @generator_commands.command(name="hide_at_limit")
     @app_commands.describe(
         enabled="Whether the feature is enabled.",
@@ -771,7 +753,7 @@ class VoiceGen(commands.Cog):
         generator: discord.VoiceChannel,
         enabled: bool,
     ):
-        """Controls whether the generator channel is hidden when the channel limit is reached."""
+        """PREMIUM - Controls whether the generator channel is hidden when the channel limit is reached."""
 
         if not interaction.guild:
             return await interaction.response.send_message(
@@ -813,8 +795,6 @@ class VoiceGen(commands.Cog):
             f"Set hide at limit for g/{interaction.guild.id} c/{generator.id} to {enabled}",
         )
 
-        return self.client.incr_counter("voice_generator_hide_at_limit")
-
     @generator_commands.command(name="force_remove")
     @check_any(command_available, is_owner)
     @app_commands.checks.has_permissions(administrator=True)
@@ -841,8 +821,6 @@ class VoiceGen(commands.Cog):
             LogLevel.DEBUG,
             f"Deleted {deleted} generator channels from the database for g/{interaction.guild.id}",
         )
-
-        return self.client.incr_counter("voice_generator_force_remove")
 
 
 async def setup(client: VCRolesClient):

--- a/cogs/generator-user.py
+++ b/cogs/generator-user.py
@@ -29,8 +29,6 @@ class GenInterface(commands.Cog):
         message = await self.utils.lock(interaction.user)
         await interaction.response.send_message(message, ephemeral=True)
 
-        return self.client.incr_counter("interface_lock")
-
     @interface_commands.command(
         name="unlock",
     )
@@ -43,8 +41,6 @@ class GenInterface(commands.Cog):
 
         message = await self.utils.unlock(interaction.user)
         await interaction.response.send_message(message, ephemeral=True)
-
-        return self.client.incr_counter("interface_unlock")
 
     @interface_commands.command(
         name="hide",
@@ -59,8 +55,6 @@ class GenInterface(commands.Cog):
         message = await self.utils.hide(interaction.user)
         await interaction.response.send_message(message, ephemeral=True)
 
-        return self.client.incr_counter("interface_hide")
-
     @interface_commands.command(name="show")
     async def unhide_interface(self, interaction: discord.Interaction):
         """Show your generated voice channel"""
@@ -71,8 +65,6 @@ class GenInterface(commands.Cog):
 
         message = await self.utils.unhide(interaction.user)
         await interaction.response.send_message(message, ephemeral=True)
-
-        return self.client.incr_counter("interface_unhide")
 
     @interface_commands.command(
         name="increase",
@@ -87,8 +79,6 @@ class GenInterface(commands.Cog):
         message = await self.utils.increase_limit(interaction.user)
         await interaction.response.send_message(message, ephemeral=True)
 
-        return self.client.incr_counter("interface_increase")
-
     @interface_commands.command(name="decrease")
     async def decrease_limit_interface(self, interaction: discord.Interaction):
         """Decrease your generated voice channel user limit"""
@@ -99,8 +89,6 @@ class GenInterface(commands.Cog):
 
         message = await self.utils.decrease_limit(interaction.user)
         await interaction.response.send_message(message, ephemeral=True)
-
-        return self.client.incr_counter("interface_decrease")
 
     @interface_commands.command(name="limit")
     @app_commands.describe(limit="The value to set the member limit to.")
@@ -116,8 +104,6 @@ class GenInterface(commands.Cog):
         message = await self.utils.set_limit(interaction.user, limit)
         await interaction.response.send_message(message, ephemeral=True)
 
-        return self.client.incr_counter("interface_decrease")
-
     @interface_commands.command(name="rename")
     @app_commands.describe(name="The new name.")
     async def rename_channel(self, interaction: discord.Interaction, name: str):
@@ -130,8 +116,6 @@ class GenInterface(commands.Cog):
         message = await self.utils.rename(interaction.user, name)
         await interaction.response.send_message(message, ephemeral=True)
 
-        return self.client.incr_counter("interface_rename")
-
     @interface_commands.command(name="claim")
     async def claim_channel(self, interaction: discord.Interaction):
         """Claim a generated channel (if owner has left)"""
@@ -143,8 +127,6 @@ class GenInterface(commands.Cog):
         message = await self.utils.claim(interaction.user)
         await interaction.response.send_message(message, ephemeral=True)
 
-        return self.client.incr_counter("interface_claim")
-
     @interface_commands.command(name="invite")
     @app_commands.describe(user="The user to invite.", message="The message to send.")
     async def invite_user(
@@ -153,7 +135,7 @@ class GenInterface(commands.Cog):
         user: discord.Member,
         message: Optional[str],
     ):
-        """Invite a user to your channel"""
+        """PREMIUM - Invite a user to your channel"""
         if not isinstance(interaction.user, discord.Member) or not interaction.guild:
             return await interaction.response.send_message(
                 "You must be in a guild to use this.", ephemeral=True
@@ -189,8 +171,6 @@ class GenInterface(commands.Cog):
 
         await interaction.response.send_message(return_message, ephemeral=True)
 
-        return self.client.incr_counter("interface_invite")
-
     @interface_commands.command(name="permit")
     async def permit_mentionable(self, interaction: discord.Interaction):
         """Permits roles/users to join you."""
@@ -212,8 +192,6 @@ class GenInterface(commands.Cog):
             delete_after=60,
         )
 
-        return self.client.incr_counter("interface_permit")
-
     @interface_commands.command(name="restrict")
     async def restrict_mentionable(self, interaction: discord.Interaction):
         """Restricts roles/users to join you."""
@@ -234,8 +212,6 @@ class GenInterface(commands.Cog):
             ),
             delete_after=60,
         )
-
-        return self.client.incr_counter("interface_restrict")
 
 
 class MentionableView(discord.ui.View):

--- a/cogs/linked.py
+++ b/cogs/linked.py
@@ -177,8 +177,6 @@ class Linked(commands.Cog):
             f"Ran linked command g/{interaction.guild_id} m/{interaction.user.id}",
         )
 
-        return self.client.incr_counter("linked")
-
 
 async def setup(client: VCRolesClient):
     await client.add_cog(Linked(client))

--- a/cogs/linking-commands.py
+++ b/cogs/linking-commands.py
@@ -53,8 +53,6 @@ class Linking(commands.Cog):
             f"Linked c/{channel.id} g/{interaction.guild_id} r/{role.id}",
         )
 
-        return self.client.incr_counter("link")
-
     @app_commands.command()
     @app_commands.describe(
         channel="Select a channel to unlink", role="Select a role to unlink"
@@ -79,8 +77,6 @@ class Linking(commands.Cog):
             LogLevel.DEBUG,
             f"Unlinked c/{channel.id} g/{interaction.guild_id} r/{role.id}",
         )
-
-        return self.client.incr_counter("unlink")
 
     @suffix_commands.command()
     @app_commands.describe(
@@ -108,8 +104,6 @@ class Linking(commands.Cog):
             f"Added suffix c/{channel.id} g/{interaction.guild_id} s/{suffix}",
         )
 
-        return self.client.incr_counter("add_suffix")
-
     @suffix_commands.command()
     @app_commands.describe(channel="Select a channel to link")
     @check_any(command_available, is_owner)
@@ -131,8 +125,6 @@ class Linking(commands.Cog):
             LogLevel.DEBUG,
             f"Removed suffix c/{channel.id} g/{interaction.guild_id}",
         )
-
-        return self.client.incr_counter("remove_suffix")
 
     @reverse_commands.command(name="link")
     @app_commands.describe(
@@ -159,8 +151,6 @@ class Linking(commands.Cog):
             f"Reverse linked c/{channel.id} g/{interaction.guild_id} r/{role.id}",
         )
 
-        return self.client.incr_counter("reverse_link")
-
     @reverse_commands.command(name="unlink")
     @app_commands.describe(
         channel="Select a channel to link", role="Select a role to link"
@@ -185,8 +175,6 @@ class Linking(commands.Cog):
             LogLevel.DEBUG,
             f"Reverse unlinked c/{channel.id} g/{interaction.guild_id} r/{role.id}",
         )
-
-        return self.client.incr_counter("reverse_unlink")
 
 
 async def setup(client: VCRolesClient):

--- a/cogs/logging.py
+++ b/cogs/logging.py
@@ -56,8 +56,6 @@ class Logging(commands.Cog):
             f"Logging {'enabled' if enabled else 'disabled'} g/{interaction.guild.id}",
         )
 
-        return self.client.incr_counter("logging")
-
 
 async def setup(client: VCRolesClient):
     await client.add_cog(Logging(client))

--- a/cogs/permanent-link.py
+++ b/cogs/permanent-link.py
@@ -51,8 +51,6 @@ class PermLink(commands.Cog):
             f"Permanent linked c/{channel.id} g/{interaction.guild_id} r/{role.id}",
         )
 
-        return self.client.incr_counter("perm_link")
-
     @perm_commands.command()
     @app_commands.describe(
         channel="Select a channel to unlink", role="Select a role to unlink"
@@ -77,8 +75,6 @@ class PermLink(commands.Cog):
             LogLevel.DEBUG,
             f"Permanent unlinked c/{channel.id} g/{interaction.guild_id} r/{role.id}",
         )
-
-        return self.client.incr_counter("perm_unlink")
 
     @suffix_commands.command()
     @app_commands.describe(
@@ -106,8 +102,6 @@ class PermLink(commands.Cog):
             f"Permanent suffix added c/{channel.id} g/{interaction.guild_id} s/{suffix}",
         )
 
-        return self.client.incr_counter("perm_suffix_add")
-
     @suffix_commands.command()
     @app_commands.describe(channel="Select a channel to remove a suffix rule from")
     @check_any(command_available, is_owner)
@@ -129,8 +123,6 @@ class PermLink(commands.Cog):
             LogLevel.DEBUG,
             f"Permanent suffix removed c/{channel.id} g/{interaction.guild_id}",
         )
-
-        return self.client.incr_counter("perm_suffix_remove")
 
     @reverse_commands.command(
         name="link",
@@ -159,8 +151,6 @@ class PermLink(commands.Cog):
             f"Permanent reverse linked c/{channel.id} g/{interaction.guild_id} r/{role.id}",
         )
 
-        return self.client.incr_counter("perm_reverse_link")
-
     @reverse_commands.command(
         name="unlink",
     )
@@ -187,8 +177,6 @@ class PermLink(commands.Cog):
             LogLevel.DEBUG,
             f"Permanent reverse unlinked c/{channel.id} g/{interaction.guild_id} r/{role.id}",
         )
-
-        return self.client.incr_counter("perm_reverse_unlink")
 
 
 async def setup(client: VCRolesClient):

--- a/cogs/ping.py
+++ b/cogs/ping.py
@@ -17,8 +17,6 @@ class Ping(commands.Cog):
             f"Pong! {round(self.client.latency*1000,1)} ms"
         )
 
-        return self.client.incr_counter("ping")
-
 
 async def setup(client: VCRolesClient):
     await client.add_cog(Ping(client))

--- a/cogs/premium.py
+++ b/cogs/premium.py
@@ -26,27 +26,27 @@ class Premium(commands.Cog):
         name="premium", description="Premium commands"
     )
 
-    async def verify_license(self, license_key: str) -> Tuple[bool, int]:
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                "https://api.gumroad.com/v2/licenses/verify",
-                json={
-                    "license_key": license_key,
-                    "product_id": config.GUMROAD_PRODUCT_ID,
-                },
-            ) as r:
-                res = await r.json()
-                if res["success"]:
-                    if res["purchase"]["variants"] == "(Premium)":
-                        return True, 1
-                    elif res["purchase"]["variants"] == "(Premium Plus)":
-                        return True, 3
-                    elif res["purchase"]["variants"] == "(Premium Pro)":
-                        return True, 10
-                    else:
-                        return False, 0
+    @staticmethod
+    async def verify_license(license_key: str) -> Tuple[bool, int]:
+        async with aiohttp.ClientSession() as session, session.post(
+            "https://api.gumroad.com/v2/licenses/verify",
+            json={
+                "license_key": license_key,
+                "product_id": config.GUMROAD_PRODUCT_ID,
+            },
+        ) as r:
+            res = await r.json()
+            if res["success"]:
+                if res["purchase"]["variants"] == "(Premium)":
+                    return True, 1
+                elif res["purchase"]["variants"] == "(Premium Plus)":
+                    return True, 3
+                elif res["purchase"]["variants"] == "(Premium Pro)":
+                    return True, 10
                 else:
                     return False, 0
+            else:
+                return False, 0
 
     @premium_commands.command(name="activate")
     async def premium_activate(self, interaction: Interaction, license_key: str):

--- a/cogs/premium.py
+++ b/cogs/premium.py
@@ -1,0 +1,313 @@
+from typing import Tuple
+import aiohttp
+from discord.ext import commands, tasks
+from discord import app_commands, Interaction
+import config
+from utils.client import VCRolesClient
+import datetime as dt
+from prisma.enums import VoiceGeneratorOption
+import discord
+from views.url import Premium as PremiumView
+
+
+class Premium(commands.Cog):
+    def __init__(self, client: VCRolesClient):
+        self.client = client
+        self.premium_check.start()
+
+    async def cog_unload(self):
+        self.premium_check.cancel()
+
+        return await super().cog_unload()
+
+    premium_commands = app_commands.Group(
+        name="premium", description="Premium commands"
+    )
+
+    async def verify_license(self, license_key: str) -> Tuple[bool, int]:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                "https://api.gumroad.com/v2/licenses/verify",
+                json={
+                    "license_key": license_key,
+                    "product_id": config.GUMROAD_PRODUCT_ID,
+                },
+            ) as r:
+                res = await r.json()
+                if res["success"]:
+                    if res["purchase"]["variants"] == "(Premium)":
+                        return True, 1
+                    elif res["purchase"]["variants"] == "(Premium Plus)":
+                        return True, 3
+                    elif res["purchase"]["variants"] == "(Premium Pro)":
+                        return True, 10
+                    else:
+                        return False, 0
+                else:
+                    return False, 0
+
+    @premium_commands.command(name="activate")
+    async def premium_activate(self, interaction: Interaction, license_key: str):
+        """Activate your premium subscription"""
+        valid, max_guilds = await self.verify_license(license_key)
+        if valid:
+            await interaction.response.send_message(
+                f"Your license is valid! You can now add up to {max_guilds} guilds to your premium subscription."
+            )
+            if not await self.client.db.db.premium.find_first(
+                where={"licenseKey": license_key}
+            ):
+                await self.client.db.db.premium.create(
+                    data={
+                        "licenseKey": license_key,
+                        "maxGuilds": max_guilds,
+                        "userId": str(interaction.user.id),
+                    },
+                )
+            else:
+                await self.client.db.db.premium.update(
+                    where={"licenseKey": license_key},
+                    data={"userId": str(interaction.user.id), "maxGuilds": max_guilds},
+                )
+            await self.client.ar.hset("premium", str(interaction.user.id), 1)
+        else:
+            await interaction.response.send_message("Invalid license key.")
+
+    @premium_commands.command(name="add")
+    async def premium_add(self, interaction: Interaction):
+        """PREMIUM - Add a guild to your premium subscription"""
+        await interaction.response.defer()
+        # check if user is premium
+        p = await self.client.db.db.premium.find_first(
+            where={"userId": str(interaction.user.id)},
+            include={"guilds": True},
+        )
+        if not p:
+            await interaction.followup.send(
+                "You do not have a premium subscription. Activate one with `/premium activate <license_key>`."
+            )
+            return
+        # check if guild exists
+        if not interaction.guild:
+            await interaction.followup.send("This command can only be used in a guild.")
+            return
+        guild_id = interaction.guild.id
+        d_guild = interaction.guild
+        # check if guild is already premium
+        guild = await self.client.db.get_guild_data(guild_id)
+        if guild.premium:
+            await interaction.followup.send("This guild is already premium.")
+            return
+        # check if user has max guilds
+        if p.guilds and len(p.guilds) >= p.maxGuilds:
+            await interaction.followup.send(
+                "You have reached the maximum number of guilds you can add to your premium subscription."
+            )
+            return
+        # add guild to premium
+        await self.client.db.db.guild.update(
+            where={"id": str(guild_id)},
+            data={
+                "premium": True,
+                "Premium": {"connect": {"id": p.id}},
+            },
+        )
+        self.client.db.remove_guild_from_cache(guild_id)
+        await interaction.followup.send(
+            f"Added {d_guild.name} to your premium subscription."
+        )
+
+    @premium_commands.command(name="remove")
+    async def premium_remove(self, interaction: Interaction):
+        """PREMIUM - Remove a guild from premium. CAUTION: Premium features instantly removed."""
+        await interaction.response.defer()
+        # check if user is premium
+        p = await self.client.db.db.premium.find_first(
+            where={"userId": str(interaction.user.id)},
+            include={"guilds": True},
+        )
+        if not p:
+            await interaction.followup.send(
+                "You do not have a premium subscription. Activate one with `/premium activate <license_key>`."
+            )
+            return
+        # check if guild exists
+        if not interaction.guild:
+            await interaction.followup.send("This command can only be used in a guild.")
+            return
+        guild_id = interaction.guild.id
+        d_guild = interaction.guild
+        # check if guild is premium
+        guild = await self.client.db.get_guild_data(guild_id)
+        if not guild.premium:
+            await interaction.followup.send("This guild is not premium.")
+            return
+        # remove guild from premium
+        await self.remove_premium(guild_id)
+        await interaction.followup.send(
+            f"Removed {d_guild.name} from your premium subscription."
+        )
+
+    @premium_commands.command(name="list")
+    async def premium_list(self, interaction: Interaction):
+        """PREMIUM - List all guilds you have added to your premium subscription"""
+        # check if user is premium
+        p = await self.client.db.db.premium.find_first(
+            where={"userId": str(interaction.user.id)},
+            include={"guilds": True},
+        )
+        if not p:
+            await interaction.response.send_message(
+                "You do not have a premium subscription. Activate one with `/premium activate <license_key>`."
+            )
+            return
+        # list guilds
+        if not p.guilds:
+            await interaction.response.send_message(
+                "You have no guilds added to your premium subscription."
+            )
+            return
+        guilds: list[str] = []
+        for guild in p.guilds:
+            d_guild = self.client.get_guild(int(guild.id))
+            if d_guild:
+                guilds.append(d_guild.name)
+            else:
+                guilds.append(guild.id)
+        await interaction.response.send_message(
+            f"Guilds you have added to your premium subscription: {', '.join(guilds)}"
+        )
+
+    @premium_commands.command(name="info")
+    async def premium_info(self, interaction: Interaction):
+        """PREMIUM - Get information about your premium subscription"""
+        # check if user is premium
+        p = await self.client.db.db.premium.find_first(
+            where={"userId": str(interaction.user.id)},
+            include={"guilds": True},
+        )
+        if not p:
+            await interaction.response.send_message(
+                "You do not have a premium subscription. Activate one with `/premium activate <license_key>`."
+            )
+            return
+        # get info
+        tier = (
+            "Premium"
+            if p.maxGuilds == 1
+            else "Premium Plus"
+            if p.maxGuilds == 3
+            else "Premium Pro"
+            if p.maxGuilds == 10
+            else "Custom Premium"
+        )
+        await interaction.response.send_message(
+            f"Your premium subscription ({tier}) has {p.maxGuilds} slots and you have added {len(p.guilds) if p.guilds else 0} guilds."
+        )
+
+    @premium_commands.command(name="buy")
+    async def premium_buy(self, interaction: Interaction):
+        """Purchase a premium subscription"""
+        await interaction.response.send_message(
+            "You can purchase a premium subscription at https://premium.vcroles.com/l/vcroles",
+            view=PremiumView(),
+        )
+
+    async def remove_premium(self, guild_id: int):
+        """Remove premium from a guild"""
+        await self.client.db.db.guild.update(
+            where={"id": str(guild_id)},
+            data={
+                "premium": False,
+                "Premium": {"disconnect": True},
+            },
+        )
+        self.client.db.remove_guild_from_cache(guild_id)
+        generators = await self.client.db.db.voicegenerator.find_many(
+            where={"guildId": str(guild_id)},
+        )
+        while len(generators) > 1:
+            await self.client.db.db.voicegenerator.delete(
+                where={"id": str(generators[0].id)}
+            )
+            generators.pop(0)
+        if not generators:
+            return
+        generator = generators[0]
+        if VoiceGeneratorOption.TEXT in generator.defaultOptions:
+            generator.defaultOptions.remove(VoiceGeneratorOption.TEXT)
+            await self.client.db.db.voicegenerator.update(
+                where={"id": str(generators[0].id)},
+                data={
+                    "defaultOptions": generator.defaultOptions,
+                },
+            )
+        if generator.hideAtLimit:
+            await self.client.db.db.voicegenerator.update(
+                where={"id": str(generators[0].id)},
+                data={
+                    "hideAtLimit": False,
+                },
+            )
+
+    @tasks.loop(time=[dt.time(hour=0, minute=0)])
+    async def premium_check(self):
+        """Check if premium subscriptions have expired"""
+        # get all premium subscriptions
+        premium = await self.client.db.db.premium.find_many(
+            include={"guilds": True},
+        )
+        for p in premium:
+            active, max_guilds = await self.verify_license(p.licenseKey)
+            if not active:
+                if p.strike >= 3:
+                    for guild in p.guilds or []:
+                        await self.remove_premium(int(guild.id))
+                    await self.client.db.db.premium.delete(where={"id": p.id})
+                    await self.client.ar.hset(
+                        "premium",
+                        p.userId,
+                        0,
+                    )
+                    try:
+                        user = await self.client.fetch_user(int(p.userId))
+                    except discord.NotFound:
+                        continue
+                    except discord.HTTPException:
+                        continue
+                    try:
+                        await user.send(
+                            "Your premium subscription has expired and has been removed. You can reactivate your subscription with `/premium activate <license_key>`. Or you can buy a new subscription with `/premium buy`."
+                        )
+                    except discord.Forbidden:
+                        pass
+                else:
+                    await self.client.db.db.premium.update(
+                        where={"id": p.id},
+                        data={"strike": p.strike + 1},
+                    )
+                    try:
+                        user = await self.client.fetch_user(int(p.userId))
+                    except discord.NotFound:
+                        continue
+                    except discord.HTTPException:
+                        continue
+                    try:
+                        await user.send(
+                            f"Your premium subscription has expired. You have {3 - p.strike} days left before your guilds are removed from your subscription. This will cause data loss and premium features will stop working. https://cde90.gumroad.com/l/vcroles"
+                        )
+                    except discord.Forbidden:
+                        pass
+            else:
+                await self.client.db.db.premium.update(
+                    where={"id": p.id},
+                    data={"maxGuilds": max_guilds, "strike": 0},
+                )
+
+    @premium_check.before_loop
+    async def before_premium_check(self):
+        await self.client.wait_until_ready()
+
+
+async def setup(client: VCRolesClient):
+    await client.add_cog(Premium(client))

--- a/cogs/premium.py
+++ b/cogs/premium.py
@@ -1,12 +1,14 @@
+import datetime as dt
 from typing import Tuple
+
 import aiohttp
+import discord
+from discord import Interaction, app_commands
 from discord.ext import commands, tasks
-from discord import app_commands, Interaction
+from prisma.enums import VoiceGeneratorOption
+
 import config
 from utils.client import VCRolesClient
-import datetime as dt
-from prisma.enums import VoiceGeneratorOption
-import discord
 from views.url import Premium as PremiumView
 
 

--- a/cogs/stage-speaker-link.py
+++ b/cogs/stage-speaker-link.py
@@ -46,8 +46,6 @@ class StageSpeaker(commands.Cog):
             f"Speaker linked c/{channel.id} g/{interaction.guild_id} r/{role.id}",
         )
 
-        return self.client.incr_counter("speaker_link")
-
     @speaker_commands.command()
     @app_commands.describe(
         channel="Select a channel to unlink", role="Select a role to unlink"
@@ -72,8 +70,6 @@ class StageSpeaker(commands.Cog):
             LogLevel.DEBUG,
             f"Speaker unlinked c/{channel.id} g/{interaction.guild_id} r/{role.id}",
         )
-
-        return self.client.incr_counter("speaker_unlink")
 
 
 async def setup(client: VCRolesClient):

--- a/cogs/tts.py
+++ b/cogs/tts.py
@@ -161,8 +161,6 @@ class TTS(commands.Cog):
             f"TTS played: g/{interaction.guild.id} m/{interaction.user.id}",
         )
 
-        return self.client.incr_counter("tts_play")
-
     @tts_commands.command()
     async def stop(self, interaction: discord.Interaction):
         """Stops the current TTS message & Makes the bot leave the voice channel"""
@@ -176,7 +174,6 @@ class TTS(commands.Cog):
                     description="The current TTS message has been stopped.",
                 )
                 await interaction.response.send_message(embed=embed)
-                return self.client.incr_counter("tts_stop")
 
         embed = discord.Embed(
             colour=discord.Color.green(),
@@ -188,8 +185,6 @@ class TTS(commands.Cog):
             LogLevel.DEBUG,
             f"TTS stopped: g/{interaction.guild_id} m/{interaction.user.id}",
         )
-
-        return self.client.incr_counter("tts_stop")
 
     @tts_commands.command()
     @app_commands.describe(
@@ -228,8 +223,6 @@ class TTS(commands.Cog):
             LogLevel.DEBUG,
             f"TTS setup: g/{interaction.guild.id} m/{interaction.user.id}",
         )
-
-        return self.client.incr_counter("tts_setup")
 
 
 async def setup(client: VCRolesClient):

--- a/cogs/tts.py
+++ b/cogs/tts.py
@@ -134,6 +134,11 @@ class TTS(commands.Cog):
                     discord.FFmpegPCMAudio(source=f"tts/{interaction.guild_id}.mp3"),
                 )
 
+                if data.premium and data.analytics:
+                    self.client.incr_analytics_counter(
+                        interaction.guild.id, "tts_messages_sent"
+                    )
+
                 await asyncio.sleep(audio.info.length + 1)
 
                 if leave and data.ttsLeave:

--- a/cogs/utilities.py
+++ b/cogs/utilities.py
@@ -31,16 +31,12 @@ class Utils(commands.Cog):
             )
         )
 
-        return self.client.incr_counter("mention")
-
     @app_commands.command(name="discord")
     async def support_server(self, interaction: discord.Interaction):
         """Use to get an invite to the support server"""
         await interaction.response.send_message(
             content="To join our support server, click the link below", view=Discord()
         )
-
-        return self.client.incr_counter("discord")
 
     @app_commands.command()
     async def invite(self, interaction: Interaction):
@@ -50,16 +46,12 @@ class Utils(commands.Cog):
             view=Invite(),
         )
 
-        return self.client.incr_counter("invite")
-
     @app_commands.command()
     async def topgg(self, interaction: Interaction):
         """Use to get a link to the bot's Top.gg page"""
         await interaction.response.send_message(
             content="To visit the bot's Top.gg, click the link below", view=TopGG()
         )
-
-        return self.client.incr_counter("topgg")
 
     @app_commands.command()
     async def about(self, interaction: Interaction):
@@ -115,8 +107,6 @@ class Utils(commands.Cog):
 
         await interaction.response.send_message(embed=embed, view=Combination())
 
-        return self.client.incr_counter("about")
-
     @app_commands.command()
     async def help(self, interaction: Interaction):
         """Use to get help about the bot"""
@@ -126,8 +116,6 @@ class Utils(commands.Cog):
             colour=discord.Colour.light_grey(),
         )
         await interaction.response.send_message(embed=embed, view=Website())
-
-        return self.client.incr_counter("help")
 
     @app_commands.command()
     @app_commands.checks.has_permissions(administrator=True)
@@ -149,8 +137,6 @@ class Utils(commands.Cog):
         )
 
         await self.client.send_welcome(interaction.guild.id)
-
-        return self.client.incr_counter("update_channel")
 
 
 async def setup(client: VCRolesClient):

--- a/cogs/vc-control.py
+++ b/cogs/vc-control.py
@@ -86,8 +86,6 @@ class VCControl(commands.Cog):
             f"Muted: {len(tasks)} g/{interaction.guild_id} c/{interaction.channel_id}",
         )
 
-        return self.client.incr_counter("vc_mute")
-
     @control_commands.command()
     @app_commands.describe(who="Who to deafen:")
     @check_any(command_available, is_owner)
@@ -139,8 +137,6 @@ class VCControl(commands.Cog):
             f"Deafened: {len(tasks)} g/{interaction.guild_id} c/{interaction.channel_id}",
         )
 
-        return self.client.incr_counter("vc_deafen")
-
     @control_commands.command()
     @check_any(command_available, is_owner)
     @app_commands.checks.has_permissions(administrator=True)
@@ -180,8 +176,6 @@ class VCControl(commands.Cog):
             LogLevel.DEBUG,
             f"Unmuted: {len(tasks)} g/{interaction.guild_id} c/{interaction.channel_id}",
         )
-
-        return self.client.incr_counter("vc_unmute")
 
     @control_commands.command()
     @check_any(command_available, is_owner)
@@ -223,8 +217,6 @@ class VCControl(commands.Cog):
             LogLevel.DEBUG,
             f"Undeafened: {len(tasks)} g/{interaction.guild_id} c/{interaction.channel_id}",
         )
-
-        return self.client.incr_counter("vc_undeafen")
 
 
 async def setup(client: VCRolesClient):

--- a/cogs/voicestate.py
+++ b/cogs/voicestate.py
@@ -288,6 +288,16 @@ class VoiceState(commands.Cog):
         self.client.incr_role_counter("added", len(addable_roles))
         self.client.incr_role_counter("removed", len(removeable_roles))
 
+        guild = await self.client.db.get_guild_data(member.guild.id)
+        if guild.premium and guild.analytics:
+            self.client.incr_analytics_counter(member.guild.id, "voice_channel_joins")
+            self.client.incr_analytics_counter(
+                member.guild.id, "roles_added", len(addable_roles)
+            )
+            self.client.incr_analytics_counter(
+                member.guild.id, "roles_removed", len(removeable_roles)
+            )
+
         await self.generator.join(member, after.channel)
 
         return return_data, list(set(failed_roles))
@@ -448,6 +458,16 @@ class VoiceState(commands.Cog):
 
         self.client.incr_role_counter("added", len(addable_roles))
         self.client.incr_role_counter("removed", len(removeable_roles))
+
+        guild = await self.client.db.get_guild_data(member.guild.id)
+        if guild.premium and guild.analytics:
+            self.client.incr_analytics_counter(member.guild.id, "voice_channel_leaves")
+            self.client.incr_analytics_counter(
+                member.guild.id, "roles_added", len(addable_roles)
+            )
+            self.client.incr_analytics_counter(
+                member.guild.id, "roles_removed", len(removeable_roles)
+            )
 
         await self.generator.leave(member, before.channel)
 
@@ -650,6 +670,16 @@ class VoiceState(commands.Cog):
 
         self.client.incr_role_counter("added", len(addable_roles))
         self.client.incr_role_counter("removed", len(removeable_roles))
+
+        guild = await self.client.db.get_guild_data(member.guild.id)
+        if guild.premium and guild.analytics:
+            self.client.incr_analytics_counter(member.guild.id, "voice_channel_changes")
+            self.client.incr_analytics_counter(
+                member.guild.id, "roles_added", len(addable_roles)
+            )
+            self.client.incr_analytics_counter(
+                member.guild.id, "roles_removed", len(removeable_roles)
+            )
 
         await self.generator.leave(member, before.channel)
         await self.generator.join(member, after.channel)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model Guild {
     voiceGenerator VoiceGenerator[]
     premium        Boolean          @default(false)
     botMasterRoles String[]
+    analytics      String?
 }
 
 enum LinkType {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,17 @@ model Guild {
     premium        Boolean          @default(false)
     botMasterRoles String[]
     analytics      Boolean          @default(false)
+    Premium        Premium?         @relation(fields: [premiumId], references: [id])
+    premiumId      String?
+}
+
+model Premium {
+    id         String  @id @default(cuid())
+    licenseKey String  @unique
+    maxGuilds  Int     @default(1)
+    guilds     Guild[]
+    userId     String
+    strike     Int     @default(0)
 }
 
 enum LinkType {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,7 +19,7 @@ model Guild {
     voiceGenerator VoiceGenerator[]
     premium        Boolean          @default(false)
     botMasterRoles String[]
-    analytics      String?
+    analytics      Boolean          @default(false)
 }
 
 enum LinkType {

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ cachetools
 types-cachetools
 asyncache
 jishaku
+matplotlib
 orjson>=3.5.4 # these are discord.py's speed modules
 aiodns>=1.1
 Brotli

--- a/utils/client.py
+++ b/utils/client.py
@@ -58,6 +58,13 @@ class VCRolesClient(commands.AutoShardedBot):
         self.loop.create_task(
             self.ar.hincrby(f"guild:{guild_id}:analytics", item, count)
         )
+        self.loop.create_task(
+            self.ar.hincrby(
+                f"guild:{guild_id}:analytics",
+                f"{item}-{datetime.datetime.utcnow().strftime('%H')}",
+                count,
+            )
+        )
 
     async def on_ready(self):
         """

--- a/utils/database.py
+++ b/utils/database.py
@@ -63,7 +63,7 @@ class DatabaseUtils:
         tts_leave: Optional[bool] = None,
         logging: Optional[str] = None,
         bot_master_roles: Optional[list[str]] = None,
-        analytics: Optional[str] = None,
+        analytics: Optional[bool] = None,
     ) -> None:
         data: GuildUpdateInput = {}
 
@@ -92,10 +92,6 @@ class DatabaseUtils:
             data["analytics"] = analytics
             self.analytic_guilds = []
 
-        if analytics == "None":
-            data["analytics"] = None
-            self.analytic_guilds = []
-
         res = await self.db.guild.update(where={"id": str(guild_id)}, data=data)
         if not res:
             await self.db.guild.create(
@@ -106,7 +102,7 @@ class DatabaseUtils:
                     "ttsLeave": tts_leave if tts_leave else True,
                     "logging": logging if logging != "None" else None,
                     "botMasterRoles": bot_master_roles if bot_master_roles else [],
-                    "analytics": analytics if analytics else None,
+                    "analytics": analytics if analytics else False,
                 }
             )
 
@@ -460,7 +456,7 @@ class DatabaseUtils:
 
         # find all guilds where premium is enabled and analytics field is not null
         guilds = await self.db.guild.find_many(
-            where={"premium": True, "analytics": {"not": ""}}
+            where={"premium": True, "analytics": True}
         )
 
         self.analytic_guilds = guilds

--- a/utils/database.py
+++ b/utils/database.py
@@ -112,6 +112,13 @@ class DatabaseUtils:
         except KeyError:
             pass
 
+    def remove_guild_from_cache(self, guild_id: DiscordID) -> None:
+        try:
+            k = hashkey(self, guild_id)
+            del self.guild_cache[k]
+        except KeyError:
+            pass
+
     @cached(linked_channel_cache)
     async def get_channel_linked(
         self,

--- a/utils/database.py
+++ b/utils/database.py
@@ -92,6 +92,10 @@ class DatabaseUtils:
             data["analytics"] = analytics
             self.analytic_guilds = []
 
+        if analytics == "None":
+            data["analytics"] = None
+            self.analytic_guilds = []
+
         res = await self.db.guild.update(where={"id": str(guild_id)}, data=data)
         if not res:
             await self.db.guild.create(
@@ -454,8 +458,9 @@ class DatabaseUtils:
         if self.analytic_guilds:
             return self.analytic_guilds
 
+        # find all guilds where premium is enabled and analytics field is not null
         guilds = await self.db.guild.find_many(
-            where={"NOT": [{"analytics": None}]},
+            where={"premium": True, "analytics": {"not": ""}}
         )
 
         self.analytic_guilds = guilds

--- a/views/url.py
+++ b/views/url.py
@@ -4,6 +4,7 @@ INVITE_URL = "https://discord.com/api/oauth2/authorize?client_id=775025797034541
 DISCORD_URL = "https://discord.gg/yHU6qcgNPy"
 WEBSITE_URL = "https://www.vcroles.com"
 TOPGG_URL = "https://top.gg/bot/775025797034541107"
+PREMIUM_URL = "https://premium.vcroles.com/l/vcroles"
 
 
 class Invite(discord.ui.View):
@@ -74,6 +75,23 @@ class TopGG(discord.ui.View):
         )
 
 
+class Premium(discord.ui.View):
+    """
+    Send a Premium button
+    """
+
+    def __init__(self):
+        super().__init__()
+
+        self.add_item(
+            discord.ui.Button(
+                style=discord.ButtonStyle.url,
+                label="Premium",
+                url=PREMIUM_URL,
+            )
+        )
+
+
 class Combination(discord.ui.View):
     """
     Send a button with the:
@@ -81,6 +99,7 @@ class Combination(discord.ui.View):
     - Invite
     - Support Server
     - Top.gg Link
+    - Premium Link
     """
 
     def __init__(self):
@@ -115,5 +134,13 @@ class Combination(discord.ui.View):
                 style=discord.ButtonStyle.url,
                 label="Top.gg",
                 url=TOPGG_URL,
+            )
+        )
+
+        self.add_item(
+            discord.ui.Button(
+                style=discord.ButtonStyle.url,
+                label="Premium",
+                url=PREMIUM_URL,
             )
         )

--- a/views/url.py
+++ b/views/url.py
@@ -1,6 +1,6 @@
 import discord
 
-INVITE_URL = "https://discord.com/api/oauth2/authorize?client_id=775025797034541107&permissions=300944400&scope=bot%20applications.commands"
+INVITE_URL = "https://discord.com/api/oauth2/authorize?client_id=775025797034541107&permissions=1039166576&scope=bot%20applications.commands"
 DISCORD_URL = "https://discord.gg/yHU6qcgNPy"
 WEBSITE_URL = "https://www.vcroles.com"
 TOPGG_URL = "https://top.gg/bot/775025797034541107"

--- a/voicestate/generator.py
+++ b/voicestate/generator.py
@@ -148,6 +148,12 @@ class Generator:
                 user_limit=gen_data.defaultUserLimit,
             )
 
+        guild = await self.client.db.get_guild_data(member.guild.id)
+        if channel and guild.premium and guild.analytics:
+            self.client.incr_analytics_counter(
+                member.guild.id, "generated_voice_channels", 1
+            )
+
         if VoiceGeneratorOption.TEXT in gen_data.defaultOptions:
             text_channel = await member.guild.create_text_channel(
                 name=f"{member.display_name}-text",


### PR DESCRIPTION
Analytics Commands (Premium only):
- `/analytics toggle` - enables analytics collection in your server
- `/analytics view` - see basic stats for today
- `/analytics graph <timeframe>` - renders a graph with analytics data either from the past 30 days or per hour for the day.
- `/analytics export` - exports daily data as a csv if you want to analyse it yourself.

Premium Commands:
- `/premium activate <license_key>` - activates your premium subscription using a license key obtained from gumroad.
- `/premium add` - makes the current guild a premium guild (if you are premium & have a spare slot)
- `/premium remove` - makes the current guild a regular guild
- `/premium info` - gets info about your current premium subscription (max_guilds, tier name etc.)
- `/premium list` - lists all the guilds you have added to your premium subscription
- `/premium buy` - links you to the bot's premium page